### PR TITLE
Tensorflow 2 compatibility

### DIFF
--- a/classify.py
+++ b/classify.py
@@ -8,19 +8,19 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 image_path = sys.argv[1]
 
 # Read in the image_data
-image_data = tf.gfile.FastGFile(image_path, 'rb').read()
+image_data = tf.compat.v1.gfile.FastGFile(image_path, 'rb').read()
 
 # Loads label file, strips off carriage return
 label_lines = [line.rstrip() for line 
-                   in tf.gfile.GFile("retrained_labels.txt")]
+                   in tf.io.gfile.GFile("retrained_labels.txt")]
 
 # Unpersists graph from file
-with tf.gfile.FastGFile("retrained_graph.pb", 'rb') as f:
-    graph_def = tf.GraphDef()
+with tf.compat.v1.gfile.FastGFile("retrained_graph.pb", 'rb') as f:
+    graph_def = tf.compat.v1.GraphDef()
     graph_def.ParseFromString(f.read())
     tf.import_graph_def(graph_def, name='')
 
-with tf.Session() as sess:
+with tf.compat.v1.Session() as sess:
     # Feed the image_data as input to the graph and get first prediction
     softmax_tensor = sess.graph.get_tensor_by_name('final_result:0')
     
@@ -29,7 +29,7 @@ with tf.Session() as sess:
     
     # Sort to show labels of first prediction in order of confidence
     top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]
-    
+
     for node_id in top_k:
         human_string = label_lines[node_id]
         score = predictions[0][node_id]


### PR DESCRIPTION
Tensorflow 2 has prefixed the tensorflow 1 compatible calls with tf.compat.v1. Migrate to use new modules.